### PR TITLE
增加迷宫的作者和介绍描述

### DIFF
--- a/mazeRoom-ext.ts
+++ b/mazeRoom-ext.ts
@@ -57,7 +57,7 @@ namespace Maze{
     //%block
     //%blockNamespace=迷宫
     //%group="自定义迷宫"
-    //%blockId=setMaze block="设置作者 %author 介绍 %description"
+    //%blockId=setMazeInfo block="设置作者 %author 介绍 %description"
     export function setMazeInfo(author:string, description:string) {
         curMaze.author = author
         curMaze.description = description


### PR DESCRIPTION
在首次看到遇到一个迷宫时会出现作者与介绍文字

https://github.com/cubicbird/maze-extension/issues/10